### PR TITLE
netpipe: move sleep to comapt-header.h

### DIFF
--- a/compat-header.h
+++ b/compat-header.h
@@ -41,6 +41,7 @@
 typedef int ssize_t;
 #define poll(a, b, c)			WSAPoll(a, b, c)
 #define pollfd					WSAPOLLFD
+#define sleep(t)				Sleep((t) * 1000)
 #endif
 
 

--- a/netpipe.c
+++ b/netpipe.c
@@ -814,11 +814,7 @@ int NetPipeMain(int argc, char *argv[])
 				closesocket(source.EndSocket);
 		} else LogError("Failed to prepare the source channel: %u", ret);
 
-#ifdef _WIN32
-		Sleep(_timeout * 1000);
-#else
 		sleep(_timeout);
-#endif
 	}
 
 


### PR DESCRIPTION
compat-header.h defines compatibility layer between Windows and linux
and sleep should be part of that layer as well.