### PR TITLE
netpipe: set backlog to SOMAXCONN

### DIFF
--- a/netpipe.c
+++ b/netpipe.c
@@ -290,7 +290,7 @@ static int _PrepareChannelEnd(PCHANNEL_END End, int KeepListening, int ReceiveDo
 							ret = bind(sock, genAddr, genAddrLen);
 							if (ret == 0) {
 								LogInfo("Listening");
-								ret = listen(sock, 0);
+								ret = listen(sock, SOMAXCONN);
 								if (ret == -1)
 									LogError("Error %u", errno);
 							} else LogError("Error %u", errno);


### PR DESCRIPTION
Backlog parameter sets maximum length of the queue of pending connections. The server may not accept any connection if the value is 0, which actually happened in one of my boxes.